### PR TITLE
Merge changes from upstream to fix "rm: cannot remove '/app': Read-only file system"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
-
 Add as a first buildpack in the chain. Set `PROJECT_PATH` environment variable to point to project root. It will be promoted to slug's root, everything else will be erased. Following buildpack (e.g. nodejs) will finish slug compilation.
+
+**Disclaimer:** I may change the code without notice, so always pin to specific github version. Provided as is.
+
+# How to use:
+1. `heroku buildpacks:clear` if necessary
+2. `heroku buildpacks:set https://github.com/timanovsky/subdir-heroku-buildpack`
+3. `heroku buildpacks:add heroku/nodejs` or whatever buildpack you need for your application
+4. `heroku config:set PROJECT_PATH=projects/nodejs/frontend` pointing to what you want to be a project root.
+5. Deploy your project to Heroku.
+
+# How it works
+The buildpack takes subdirectory you configured, erases everything else, and copies that subdirectory to project root. Then normal Heroku slug compilation proceeds.


### PR DESCRIPTION
Hi

I'm on the team that maintains Heroku's build system and official buildpacks.

Very soon we are going to make a change to the Heroku build system that will mean builds using this buildpack emit warnings like:

```
remote: -----> Subdir buildpack app detected
remote: -----> Subdir buildpack in <DIRECTORY>
remote:        creating cache: /tmp/codon/tmp/cache
remote:        created tmp dir: /tmp/codon/tmp/cache/subdirXF9Kh
remote:        moving working dir: <DIRECTORY> to /tmp/codon/tmp/cache/subdirXF9Kh
remote:        cleaning build dir /app
remote: rm: cannot remove '/app': Read-only file system
```

A fix for these build log warnings has been merged into the upstream repository from which this one is forked:
https://github.com/timanovsky/subdir-heroku-buildpack/pull/10

This PR merges the changes from the upstream repository (which include that fix) back to this fork, so as to avoid these warnings in your builds in the future.

If you would like to avoid the merge commit from this PR (so that the two repository's Git histories do not diverge), then I'd recommend closing this PR as unmerged, and instead pulling upstream directly into `master` of this repo.

For more information about the upcoming Heroku build system change and why this fix was needed, see:
https://github.com/timanovsky/subdir-heroku-buildpack/issues/9

I'm also happy to answer any questions you may have via discussion on this PR :-)